### PR TITLE
fix: adding margin around list notice

### DIFF
--- a/source/php/Module/views/appearances/list.blade.php
+++ b/source/php/Module/views/appearances/list.blade.php
@@ -11,6 +11,6 @@
             'data-js-render-container' => '',
         ]
     ])
-        @include('partials.preloader')
+        @include('partials.preloader', ['classList' => ['u-margin__x--2', 'u-margin__y--2']])
     @endcollection
 @endcard

--- a/source/php/Module/views/partials/preloader.blade.php
+++ b/source/php/Module/views/partials/preloader.blade.php
@@ -4,9 +4,9 @@ style="height:170px;width:100%;" data-js-like-preloader></div>
     'message' => [
         'title' => $labels['noPostsFound'],
     ],
-    'classList' => [
-        'u-display--none'
-    ],
+    'classList' => array_merge($classList ?? [], [
+        'u-display--none',
+    ]),
     'attributeList' => [
         'data-js-no-posts-notice' => ''
     ]


### PR DESCRIPTION
This pull request includes changes to the `source/php/Module/views/appearances/list.blade.php` and `source/php/Module/views/partials/preloader.blade.php` files to enhance the flexibility of the preloader's styling by allowing additional classes to be passed.

Enhancements to preloader styling:

* [`source/php/Module/views/appearances/list.blade.php`](diffhunk://#diff-8c4491174bd9269ef91e4bd66baa03a25ece266dc316ef6bde52eab55dce96e7L14-R14): Modified the `@include('partials.preloader')` directive to pass an array of additional CSS classes (`u-margin__x--2`, `u-margin__y--2`) as the `classList` parameter.
* [`source/php/Module/views/partials/preloader.blade.php`](diffhunk://#diff-142a8d9d60e899c7f59e7a305c9db6fcf4d450c6f6181dd5ae82538d67bcd336L7-R9): Updated the `classList` array to merge with any additional classes provided, while keeping the default `u-display--none` class.